### PR TITLE
解决php脚本输出内容时，多重引号的问题。

### DIFF
--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -955,6 +955,8 @@ class Compiler
                 } else {
                     $items[] = "{$key}='{$key}'";
                 }
+            } elseif (preg_match("/\<?php (.*)?>/", $value)) {
+                $items[] = "{$key}={$value}";
             } elseif ($value !== 'false' && $value !== 'null' && $value !== 'undefined') {
                 $items[] = "{$key}='{$value}'";
             }


### PR DESCRIPTION
具体表现为 <a bar=" {foo:'bar'} "></a>会失败
